### PR TITLE
Add hidden parameters to delete checklists (Fixes #14)

### DIFF
--- a/app/views/issues/_checklist_form.html.erb
+++ b/app/views/issues/_checklist_form.html.erb
@@ -14,6 +14,7 @@
 
       <%= javascript_tag "observeIssueChecklistField('checklist_form_items', 'add_checklist_item_input', 'add_checklist_item_button', 'import_checklist_items_input');" %>
       <%= javascript_tag "createIssueChecklist(#{@issue.checklist.collect { |cli| { is_done: cli.is_done, subject: cli.subject, id: cli.id } }.to_json.html_safe});" %>
+      <%= hidden_field_tag 'with_checklist_items', 1 %>
     </p>
   </div>
 <% end if User.current.allowed_to?(:edit_checklists, @project) -%>

--- a/lib/redmine_issue_checklist/hooks/model_issue_hook.rb
+++ b/lib/redmine_issue_checklist/hooks/model_issue_hook.rb
@@ -36,8 +36,9 @@ module RedmineIssueChecklist
 
       def save_checklist_to_issue(context, create_journal)
         issue = context[:issue]
+        with_checklist_items = context[:params] && context[:params][:with_checklist_items]
         checklist_items = context[:params] && context[:params][:check_list_items]
-        issue.update_checklist_items(checklist_items, create_journal) if issue && checklist_items
+        issue.update_checklist_items(checklist_items, create_journal) if issue && with_checklist_items
       end
 
     end


### PR DESCRIPTION
Before this fix, checklists will be saved only when checklist_items exists.
So even if we delete all checklists, they have gone back.

I added new parameters for check the form was displayed or not.